### PR TITLE
Implementation of support for new PHP7 typing features

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2018 MKLab. All rights reserved.
+Copyright (c) 2014-2020 MKLab. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/codegen-utils.js
+++ b/codegen-utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 MKLab. All rights reserved.
+ * Copyright (c) 2014-2020 MKLab. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/main.js
+++ b/main.js
@@ -26,8 +26,12 @@ const codeGenerator = require('./code-generator')
 function getGenOptions () {
   return {
     phpDoc: app.preferences.get('php.gen.phpDoc'),
+    useNonEmptyArrayNotation: app.preferences.get('php.gen.useNonEmptyArrayNotation'),
     useTab: app.preferences.get('php.gen.useTab'),
-    indentSpaces: app.preferences.get('php.gen.indentSpaces')
+    indentSpaces: app.preferences.get('php.gen.indentSpaces'),
+    useStrictTypes: app.preferences.get('php.gen.useStrictTypes'),
+    classBracesOnNextLine: app.preferences.get('php.gen.classBracesOnNextLine'),
+    methodBracesOnNextLine: app.preferences.get('php.gen.methodBracesOnNextLine')
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -5,12 +5,27 @@
   "homepage": "https://github.com/nahakiole/staruml-php",
   "issues": "https://github.com/nahakiole/staruml-php/issues",
   "keywords": ["php"],
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Robin Glauser",
     "email": "robin.glauser@gmail.com",
     "url": "https://github.com/nahakiole"
   },
+  "contributors": [
+    {
+      "name": "Minkyu Lee",
+      "url": "https://github.com/niklauslee"
+    },
+    {
+      "name": "Ricardo Pereira",
+      "email": "contato@ricardopedias.com.br",
+      "url": "https://github.com/ricardopedias"
+    },
+    {
+      "name": "remi.r",
+      "url": "https://github.com/tekreme73"
+    }
+  ],
   "license": "MIT",
   "engines": {
     "staruml": "^3.0.0"

--- a/preferences/preference.json
+++ b/preferences/preference.json
@@ -14,7 +14,7 @@
     },
     "php.gen.useNonEmptyArrayNotation": {
       "text": "PHPDoc non-empty Array Notation",
-      "description": "Use non-empty array notation in PHPDoc documentation",
+      "description": "Use non-empty array notation in PHPDoc comments.",
       "type": "check",
       "default": false
     },

--- a/preferences/preference.json
+++ b/preferences/preference.json
@@ -23,6 +23,12 @@
       "description": "Number of spaces for indentation.",
       "type": "number",
       "default": 4
+    },
+    "php.gen.useStrictTypes": {
+      "text": "Use Strict Types",
+      "description": "Use strict PHP7 + types for attributes, methods and arguments.",
+      "type": "check",
+      "default": false
     }
   }
 }

--- a/preferences/preference.json
+++ b/preferences/preference.json
@@ -7,10 +7,16 @@
       "type": "section"
     },
     "php.gen.phpDoc": {
-      "text": "PHPDoc",
+      "text": "Use PHPDoc",
       "description": "Generate PHPDoc comments.",
       "type": "check",
       "default": true
+    },
+    "php.gen.useNonEmptyArrayNotation": {
+      "text": "PHPDoc non-empty Array Notation",
+      "description": "Use non-empty array notation in PHPDoc documentation",
+      "type": "check",
+      "default": false
     },
     "php.gen.useTab": {
       "text": "Use Tab",
@@ -28,7 +34,19 @@
       "text": "Use Strict Types",
       "description": "Use strict PHP7 + types for attributes, methods and arguments.",
       "type": "check",
-      "default": false
+      "default": true
+    },
+    "php.gen.classBracesOnNextLine": {
+      "text": "Class Braces on Next Line",
+      "description": "Use braces on the next line according to PSR 12.",
+      "type": "check",
+      "default": true
+    },
+    "php.gen.methodBracesOnNextLine": {
+      "text": "Method Braces on Next Line",
+      "description": "Use method braces on the next line according to PSR 12.",
+      "type": "check",
+      "default": true
     }
   }
 }


### PR DESCRIPTION
Corresponding to issue #3 
1. Enabling code generation with type hints;
2. Options to adapt the generated code to PSR 1, 2 and 12;
3. Option to choose PHPDoc notation type for typing non-empty arrays

[model-example.zip](https://github.com/nahakiole/staruml-php/files/5257581/model-example.zip)


